### PR TITLE
feat: migrate site to askmilo.pro custom domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,25 +8,25 @@
       name="description"
       content="iOS only lets Siri listen hands-free, but Siri isn't smart. MILO connects Siri's system-wide voice to GPT, Claude, Gemini, and 200+ AI models — hands-free, even in CarPlay."
     />
-    <link rel="canonical" href="https://luongnv.com/milo-website/" />
+    <link rel="canonical" href="https://askmilo.pro/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="MILO" />
-    <meta property="og:url" content="https://luongnv.com/milo-website/" />
+    <meta property="og:url" content="https://askmilo.pro/" />
     <meta property="og:title" content="MILO — Give Siri the brains of GPT, Claude & Gemini" />
     <meta
       property="og:description"
       content="Siri is the only assistant you can invoke hands-free on iOS — but it's limited. MILO bridges the gap, routing your voice to GPT, Claude, Gemini, and 200+ frontier models."
     />
-    <meta property="og:image" content="https://luongnv.com/milo-website/og-image.png" />
+    <meta property="og:image" content="https://askmilo.pro/og-image.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@luongnv89" />
-    <meta name="twitter:url" content="https://luongnv.com/milo-website/" />
+    <meta name="twitter:url" content="https://askmilo.pro/" />
     <meta name="twitter:title" content="MILO — Give Siri the brains of GPT, Claude & Gemini" />
     <meta
       name="twitter:description"
       content="Siri is the only assistant you can invoke hands-free on iOS — but it's limited. MILO bridges the gap, routing your voice to GPT, Claude, Gemini, and 200+ frontier models."
     />
-    <meta name="twitter:image" content="https://luongnv.com/milo-website/og-image.png" />
+    <meta name="twitter:image" content="https://askmilo.pro/og-image.png" />
     <meta name="twitter:image:alt" content="MILO — give Siri the brains of GPT, Claude & Gemini" />
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -46,7 +46,7 @@
     <!-- DNS prefetch for third-party domains -->
     <link rel="dns-prefetch" href="https://plausible.io" />
 
-    <script defer data-domain="luongnv.com" src="https://plausible.io/js/script.js"></script>
+    <script defer data-domain="askmilo.pro" src="https://plausible.io/js/script.js"></script>
 
     <!--
       Structured data (JSON-LD). MILO's landing page is a client-rendered SPA,
@@ -60,10 +60,10 @@
         "@graph": [
           {
             "@type": "Organization",
-            "@id": "https://luongnv.com/milo-website/#org",
+            "@id": "https://askmilo.pro/#org",
             "name": "MILO",
-            "url": "https://luongnv.com/milo-website/",
-            "logo": "https://luongnv.com/milo-website/AppIcon-180.png",
+            "url": "https://askmilo.pro/",
+            "logo": "https://askmilo.pro/AppIcon-180.png",
             "sameAs": [
               "https://twitter.com/luongnv89",
               "https://github.com/luongnv89",
@@ -73,11 +73,11 @@
           },
           {
             "@type": "WebSite",
-            "@id": "https://luongnv.com/milo-website/#website",
-            "url": "https://luongnv.com/milo-website/",
+            "@id": "https://askmilo.pro/#website",
+            "url": "https://askmilo.pro/",
             "name": "MILO",
             "description": "Give Siri the brains of GPT, Claude & Gemini — hands-free AI on iOS.",
-            "publisher": { "@id": "https://luongnv.com/milo-website/#org" }
+            "publisher": { "@id": "https://askmilo.pro/#org" }
           },
           {
             "@type": "SoftwareApplication",
@@ -85,9 +85,9 @@
             "operatingSystem": "iOS 17.6+",
             "applicationCategory": "ProductivityApplication",
             "description": "MILO connects Siri's system-wide, hands-free voice access to GPT, Claude, Gemini, Mistral, Groq, OpenRouter (200+ models), Apple Intelligence, and local Ollama. Bring your own keys; conversations stay on-device. Works in CarPlay.",
-            "url": "https://luongnv.com/milo-website/",
-            "image": "https://luongnv.com/milo-website/og-image.png",
-            "author": { "@id": "https://luongnv.com/milo-website/#org" },
+            "url": "https://askmilo.pro/",
+            "image": "https://askmilo.pro/og-image.png",
+            "author": { "@id": "https://askmilo.pro/#org" },
             "offers": {
               "@type": "Offer",
               "price": "0",

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+askmilo.pro

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -35,10 +35,10 @@ You bring your own API keys (cloud providers) and switch by voice:
 
 ## Pages
 
-- [Home](https://luongnv.com/milo-website/): Product overview, providers, founder story, FAQ.
+- [Home](https://askmilo.pro/): Product overview, providers, founder story, FAQ.
 - [Join the TestFlight beta](https://testflight.apple.com/join/rea1m7wb): Install MILO via Apple's free TestFlight beta.
-- [Privacy Policy](https://luongnv.com/milo-website/privacy-policy.html): How MILO handles data.
-- [Terms](https://luongnv.com/milo-website/terms.html): Terms of use.
+- [Privacy Policy](https://askmilo.pro/privacy-policy.html): How MILO handles data.
+- [Terms](https://askmilo.pro/terms.html): Terms of use.
 
 ## Optional
 

--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -6,17 +6,17 @@
   <title>Privacy Policy - MILO</title>
   
   <!-- Favicon -->
-  <link rel="icon" type="image/svg+xml" href="/milo-website/favicon.svg">
-  <link rel="icon" type="image/png" href="/milo-website/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/milo-website/favicon-16x16.png" sizes="16x16">
-  <link rel="apple-touch-icon" sizes="180x180" href="/milo-website/apple-touch-icon.png">
-  <link rel="mask-icon" href="/milo-website/safari-pinned-tab.svg" color="#4FACFE">
-  
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#3b82f6">
+
   <!-- PWA -->
-  <meta name="theme-color" content="#4FACFE">
+  <meta name="theme-color" content="#3b82f6">
   <meta name="apple-mobile-web-app-title" content="MILO">
   <meta name="application-name" content="MILO">
-  <meta name="msapplication-TileColor" content="#4FACFE">
+  <meta name="msapplication-TileColor" content="#3b82f6">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -51,7 +51,7 @@
 <body class="min-h-screen bg-slate-950 text-slate-100">
   <div class="max-w-4xl mx-auto px-6 py-16">
     <div class="mb-12">
-      <a href="/milo-website/" class="inline-flex items-center gap-2 text-milo-blue hover:text-milo-pink transition-colors">
+      <a href="/" class="inline-flex items-center gap-2 text-milo-blue hover:text-milo-pink transition-colors">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5">
           <path d="m15 18-6-6 6-6"/>
         </svg>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
-# robots.txt for luongnv.com/milo-website
+# robots.txt for askmilo.pro
 
 User-agent: *
 Allow: /
@@ -48,4 +48,4 @@ User-agent: Perplexity-User
 Allow: /
 
 # Sitemap
-Sitemap: https://luongnv.com/milo-website/sitemap.xml
+Sitemap: https://askmilo.pro/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://luongnv.com/milo-website/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <loc>https://askmilo.pro/</loc>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://luongnv.com/milo-website/privacy-policy.html</loc>
+    <loc>https://askmilo.pro/privacy-policy.html</loc>
     <lastmod>2025-11-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://luongnv.com/milo-website/terms.html</loc>
+    <loc>https://askmilo.pro/terms.html</loc>
     <lastmod>2025-11-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>

--- a/public/terms.html
+++ b/public/terms.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Terms of Service for MILO - Multi-Provider AI Assistant for iOS.">
   
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://luongnv.com/milo-website/terms.html" />
+  <link rel="canonical" href="https://askmilo.pro/terms.html" />
   
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="./favicon.svg">

--- a/public/thanks.html
+++ b/public/thanks.html
@@ -69,7 +69,7 @@
     <!-- Social Share Buttons -->
     <div class="flex flex-wrap items-center justify-center gap-4 mb-10">
       <a 
-        href="https://twitter.com/intent/tweet?text=I%20just%20joined%20the%20waitlist%20for%20MILO%2C%20a%20hands-free%20AI%20assistant%20for%20iOS!%20%F0%9F%8E%99%EF%B8%8F%20%F0%9F%9A%97&url=https://luongnv.com/milo-website&via=luongnv89" 
+        href="https://twitter.com/intent/tweet?text=I%20just%20joined%20the%20waitlist%20for%20MILO%2C%20a%20hands-free%20AI%20assistant%20for%20iOS!%20%F0%9F%8E%99%EF%B8%8F%20%F0%9F%9A%97&url=https://askmilo.pro&via=luongnv89"
         target="_blank" 
         rel="noopener noreferrer"
         class="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-blue-500 hover:bg-blue-600 text-white font-medium transition"
@@ -79,7 +79,7 @@
       </a>
       
       <a 
-        href="https://www.linkedin.com/sharing/share-offsite/?url=https://luongnv.com/milo-website"
+        href="https://www.linkedin.com/sharing/share-offsite/?url=https://askmilo.pro"
         target="_blank" 
         rel="noopener noreferrer"
         class="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-blue-700 hover:bg-blue-800 text-white font-medium transition"

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,11 +2,10 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 
-// Served from GitHub Pages as a project site:
-// https://luongnv.com/milo-website/
-// The base path prefixes every Vite-processed asset so they resolve under
-// the /milo-website/ subpath instead of the domain root.
+// Served from GitHub Pages at the apex custom domain:
+// https://askmilo.pro/
+// Root domain, so assets resolve at the domain root (no subpath prefix).
 export default defineConfig({
-  base: '/milo-website/',
+  base: '/',
   plugins: [react(), tailwindcss()],
 });


### PR DESCRIPTION
## What

Move the site from the `luongnv.com/milo-website/` subpath to the new apex custom domain **askmilo.pro**.

## Code changes (this PR)

- **`vite.config.js`** — `base: '/milo-website/'` → `'/'`. The make-or-break change: assets now resolve at the domain root.
- **`public/CNAME`** (new) — `askmilo.pro`. Vite copies `public/`→`dist/`, so every Actions deploy preserves the custom domain.
- **`index.html`** — canonical, `og:url`/`og:image`, `twitter:url`/`twitter:image`, all JSON-LD `@id`/`url`/`logo`/`image`, and Plausible `data-domain` → `askmilo.pro`.
- **`sitemap.xml`, `robots.txt`, `llms.txt`, `terms.html`, `thanks.html`** — URLs → `askmilo.pro`.
- **`privacy-policy.html`** — absolute `/milo-website/` icon prefixes → `/`; stale `#4FACFE` theme-color → `#3b82f6` (missed by the rebrand PR).

Left intentionally unchanged: `FEEDBACK_REPO = 'luongnv89/milo-website'` (a GitHub repo slug, not a URL).

## Verified

- `npm run build` passes; `dist/CNAME` = `askmilo.pro`; asset paths root-relative (`/assets/...`, no `/milo-website/`).
- Local `vite preview`: clean console, canonical = `https://askmilo.pro/`, favicon + og-image both 200.

## Manual steps still required (outside this PR)

1. **DNS at the registrar for `askmilo.pro`:**
   - Apex `@` A records: `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, `185.199.111.153`
   - Apex `@` AAAA records: `2606:50c0:8000::153`, `2606:50c0:8001::153`, `2606:50c0:8002::153`, `2606:50c0:8003::153`
   - `www` CNAME → `luongnv89.github.io` (GitHub auto-redirects www → apex)
2. **Settings → Pages → Custom domain** = `askmilo.pro`, then enable **Enforce HTTPS** once the cert provisions (minutes–hour after DNS verifies).
3. **Plausible dashboard** — add `askmilo.pro` as a new site, or stats stop recording.

Note: setting this domain means `luongnv.com/milo-website` stops serving this site (one custom domain per repo) — intended.