### PR TITLE
feat: add Google Analytics 4 (G-9777JT54WG)

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,11 +42,23 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://plausible.io" />
+    <link rel="preconnect" href="https://www.googletagmanager.com" />
 
     <!-- DNS prefetch for third-party domains -->
     <link rel="dns-prefetch" href="https://plausible.io" />
+    <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
 
     <script defer data-domain="askmilo.pro" src="https://plausible.io/js/script.js"></script>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-9777JT54WG"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-9777JT54WG');
+    </script>
 
     <!--
       Structured data (JSON-LD). MILO's landing page is a client-rendered SPA,


### PR DESCRIPTION
## What

Add Google Analytics 4 (measurement ID `G-9777JT54WG`) to `index.html`, alongside the existing Plausible analytics.

## Changes

- `index.html` — the standard gtag.js snippet, placed right after the Plausible script.
- Added `preconnect` + `dns-prefetch` for `www.googletagmanager.com` so the tag loads fast.

Both analytics run together: Plausible (privacy-friendly, `askmilo.pro`) and GA4 (Google ecosystem).

## Verified (local preview)

- `npm run build` passes; gtag snippet present in `dist/index.html`.
- `window.gtag` defined, `dataLayer` populated.
- `gtag/js?id=G-9777JT54WG` loads (200) and a `page_view` event fires to `google-analytics.com/g/collect` with `tid=G-9777JT54WG` (204) — live collection confirmed.

Note: GA's measurement ID is public by design (shipped in client HTML); not a secret.