### PR TITLE
refactor(screens): present app screenshots as a slideshow (#5)

### DIFF
--- a/src/components/ScreenshotsSection.jsx
+++ b/src/components/ScreenshotsSection.jsx
@@ -1,8 +1,26 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
 import { screenshotGroups } from '../data/content.js';
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion.js';
+
+// Flatten the themed groups into one slide per screenshot, carrying the group's
+// title + description along so each slide keeps its marketing context. The data
+// in content.js is consumed as-is — we only reshape it for the carousel here.
+function buildSlides(groups) {
+  return groups.flatMap((group) =>
+    group.shots.map((shot) => ({
+      ...shot,
+      groupId: group.id,
+      groupTitle: group.title,
+      groupDescription: group.description,
+    }))
+  );
+}
 
 function PhoneShot({ shot }) {
   return (
-    <figure className="flex w-56 flex-col items-center">
+    <div className="w-56">
       {/* iPhone frame — same mockup as the hero, fixed width so every shot matches */}
       <div className="w-full rounded-[2.25rem] bg-slate-900 p-[6px] shadow-2xl ring-1 ring-white/10">
         <div className="relative overflow-hidden rounded-[1.9rem] bg-black">
@@ -21,12 +39,39 @@ function PhoneShot({ shot }) {
           </div>
         </div>
       </div>
-      <figcaption className="mt-4 text-center text-sm text-white/70">{shot.caption}</figcaption>
-    </figure>
+    </div>
   );
 }
 
 export function ScreenshotsSection() {
+  const slides = useMemo(() => buildSlides(screenshotGroups), []);
+  const [active, setActive] = useState(0);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const count = slides.length;
+
+  const goTo = useCallback(
+    (index) => setActive(((index % count) + count) % count),
+    [count]
+  );
+  const prev = useCallback(() => goTo(active - 1), [active, goTo]);
+  const next = useCallback(() => goTo(active + 1), [active, goTo]);
+
+  // Arrow-key navigation when the carousel region (or a child) has focus.
+  const onKeyDown = useCallback(
+    (event) => {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        prev();
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        next();
+      }
+    },
+    [prev, next]
+  );
+
+  const current = slides[active];
+
   return (
     <section id="screens" className="bg-slate-950 py-20">
       <div className="mx-auto max-w-6xl px-6">
@@ -37,23 +82,91 @@ export function ScreenshotsSection() {
           </p>
         </div>
 
-        <div className="space-y-16">
-          {screenshotGroups.map((group) => (
-            <div key={group.id} className="glass rounded-3xl p-6 sm:p-10">
-              <div className="mx-auto max-w-2xl text-center">
-                <h3 className="font-display text-xl font-semibold text-white sm:text-2xl">
-                  {group.title}
-                </h3>
-                <p className="mt-3 text-sm leading-relaxed text-white/70">{group.description}</p>
-              </div>
+        <div
+          className="glass relative mx-auto max-w-3xl rounded-3xl p-6 sm:p-10"
+          role="group"
+          aria-roledescription="carousel"
+          aria-label="MILO app screenshots"
+          tabIndex={0}
+          onKeyDown={onKeyDown}
+        >
+          {/* Group context for the active slide */}
+          <div className="mx-auto max-w-2xl text-center">
+            <h3 className="font-display text-xl font-semibold text-white sm:text-2xl">
+              {current.groupTitle}
+            </h3>
+            <p className="mt-3 text-sm leading-relaxed text-white/70">{current.groupDescription}</p>
+          </div>
 
-              <div className="mt-10 flex flex-wrap justify-center gap-x-8 gap-y-12">
-                {group.shots.map((shot) => (
-                  <PhoneShot key={shot.src} shot={shot} />
-                ))}
-              </div>
+          {/* Slides — only the active one is shown; the rest stay mounted but hidden
+              so lazy-loaded images can warm up and assistive tech can count them. */}
+          <div className="mt-10 flex items-start justify-center">
+            {slides.map((shot, index) => {
+              const isActive = index === active;
+              return (
+                <figure
+                  key={shot.src}
+                  className={`flex-col items-center ${isActive ? 'flex' : 'hidden'} ${
+                    isActive && !prefersReducedMotion ? 'animate-fade-in' : ''
+                  }`}
+                  role="group"
+                  aria-roledescription="slide"
+                  aria-label={`${index + 1} of ${count}`}
+                  aria-hidden={!isActive}
+                >
+                  <PhoneShot shot={shot} />
+                  <figcaption className="mt-4 text-center text-sm text-white/70">
+                    {shot.caption}
+                  </figcaption>
+                </figure>
+              );
+            })}
+          </div>
+
+          {/* Controls */}
+          <div className="mt-8 flex items-center justify-center gap-4">
+            <button
+              type="button"
+              onClick={prev}
+              aria-label="Previous screenshot"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-white/5 text-white/80 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-milo-blue"
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </button>
+
+            <div className="flex items-center gap-2" role="tablist" aria-label="Choose screenshot">
+              {slides.map((shot, index) => {
+                const isActive = index === active;
+                return (
+                  <button
+                    key={shot.src}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    aria-label={`Go to screenshot ${index + 1}: ${shot.caption}`}
+                    onClick={() => goTo(index)}
+                    className={`h-2.5 rounded-full transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-milo-blue ${
+                      isActive ? 'w-6 bg-milo-blue' : 'w-2.5 bg-white/25 hover:bg-white/40'
+                    }`}
+                  />
+                );
+              })}
             </div>
-          ))}
+
+            <button
+              type="button"
+              onClick={next}
+              aria-label="Next screenshot"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-white/5 text-white/80 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-milo-blue"
+            >
+              <ChevronRight className="h-5 w-5" />
+            </button>
+          </div>
+
+          {/* Live position for screen readers */}
+          <p className="mt-4 text-center text-xs text-white/45" aria-live="polite">
+            {active + 1} / {count}
+          </p>
         </div>
       </div>
     </section>

--- a/src/components/ScreenshotsSection.jsx
+++ b/src/components/ScreenshotsSection.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 import { screenshotGroups } from '../data/content.js';
@@ -11,7 +11,6 @@ function buildSlides(groups) {
   return groups.flatMap((group) =>
     group.shots.map((shot) => ({
       ...shot,
-      groupId: group.id,
       groupTitle: group.title,
       groupDescription: group.description,
     }))
@@ -98,8 +97,9 @@ export function ScreenshotsSection() {
             <p className="mt-3 text-sm leading-relaxed text-white/70">{current.groupDescription}</p>
           </div>
 
-          {/* Slides — only the active one is shown; the rest stay mounted but hidden
-              so lazy-loaded images can warm up and assistive tech can count them. */}
+          {/* Slides — only the active one is shown (the rest are display:none, so
+              they're out of the a11y tree and not focusable). Keeping every slide
+              mounted keeps the markup simple and the keys stable across navigation. */}
           <div className="mt-10 flex items-start justify-center">
             {slides.map((shot, index) => {
               const isActive = index === active;
@@ -134,15 +134,14 @@ export function ScreenshotsSection() {
               <ChevronLeft className="h-5 w-5" />
             </button>
 
-            <div className="flex items-center gap-2" role="tablist" aria-label="Choose screenshot">
+            <div className="flex items-center gap-2">
               {slides.map((shot, index) => {
                 const isActive = index === active;
                 return (
                   <button
                     key={shot.src}
                     type="button"
-                    role="tab"
-                    aria-selected={isActive}
+                    aria-current={isActive ? 'true' : undefined}
                     aria-label={`Go to screenshot ${index + 1}: ${shot.caption}`}
                     onClick={() => goTo(index)}
                     className={`h-2.5 rounded-full transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-milo-blue ${

--- a/src/index.css
+++ b/src/index.css
@@ -54,6 +54,22 @@ body {
   box-shadow: var(--shadow-glow);
 }
 
+/* Slide entrance for the screenshots carousel.
+   Honors prefers-reduced-motion via the global rule at the bottom of this file. */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.animate-fade-in {
+  animation: fade-in 0.35s ease-out;
+}
+
 /* Soft accent glow used once behind the hero */
 .hero-glow::before {
   content: '';


### PR DESCRIPTION
Closes #5

## Summary

The "See MILO in action" section previously stacked all nine app screenshots down a long, scrolling page. This replaces that section with a slideshow that shows **one screenshot per slide** (9 slides), each carrying its theme's title and description. The page is now much shorter and the showcase is interactive.

## Approach

Per the user's choice (one-screenshot-per-slide, confirmed up front), `screenshotGroups` is consumed as-is and flattened in-component into 9 slides — each slide keeps its group's `title`/`description` so the marketing copy is preserved. State is a single `useState` index with wrap-around navigation, mirroring the existing `HelpSection` tab idiom. No new dependency.

The iPhone-frame mockup, image `BASE_URL` prefix, `alt` text, captions, and the `#screens` anchor (used by `navLinks`) are all preserved.

## Decision Record

- **One slide per screenshot (B), not one slide per group (A).** B is the everyday meaning of "slideshow," is trivially responsive (a single phone at a time), and preserves all 9 shots plus the per-theme copy. A would have put 2–3 phones side-by-side per slide, fighting the responsive criterion on narrow screens. Confirmed with the reporter before building.
- **No carousel library.** A `useState` index + Tailwind matches the codebase (HelpSection's tab pattern) and keeps the bundle lean.
- **Dots are plain buttons with `aria-current`, not `role="tab"`.** A `tablist`/`tab` pattern implies arrow keys roving focus *between* tabs; here arrows change the slide, so `aria-current` describes the real behavior (changed during review).
- **Motion gated twice.** The slide fade-in is gated by the existing `usePrefersReducedMotion` hook *and* the global `prefers-reduced-motion` CSS block.

## Changes

| File | Change |
|------|--------|
| `src/components/ScreenshotsSection.jsx` | Rewrote the stacked grid as a single-slide carousel: flatten groups → 9 slides, `useState` index with modulo wrap, prev/next buttons + dot indicators (`aria-current`), `ArrowLeft`/`ArrowRight` keyboard nav, carousel/slide ARIA roles, `aria-live` position indicator. |
| `src/index.css` | Added a `fade-in` keyframe + `.animate-fade-in` utility for the slide entrance (honors the existing reduced-motion rule). |

## Test Results

No test framework is configured (`verify` = `vite build`). Verified two ways:

- `npm run build` — passes clean.
- **Live browser QA** (Vite dev server, headless Chromium) at 375 / 768 / 1280px:
  - Exactly **1 of 9** screenshots visible at a time.
  - Next button: 1/9 → 2/9, caption + group title update.
  - Dot click: jumps to the chosen slide; active dot gets `aria-current="true"`.
  - Keyboard: `ArrowRight`/`ArrowLeft` change slides; wrap-around works (slide 1 + ArrowLeft → 9/9).
  - **No horizontal overflow** on mobile (scrollWidth == innerWidth at 375px).
  - "X / 9" indicator tracks the active slide.
  - No new console errors (a pre-existing `fetchpriority` warning in `HeroSection.jsx` is unrelated and out of scope).

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| Screenshots presented in a slideshow/carousel instead of a stacked list | ✅ Verified — 1 of 9 visible, page shortened |
| Users can navigate between slides (next/prev controls and/or swipe) | ✅ Verified — prev/next buttons + dot indicators |
| All screenshots currently shown remain present and viewable | ✅ All 9 from `screenshotGroups` flattened, none dropped |
| Responsive on mobile and desktop | ✅ Verified at 375 / 768 / 1280px, no overflow |
| Keyboard-accessible and screen-reader friendly | ✅ Arrow-key nav, `aria-label`s, carousel/slide roles, `aria-current`, `aria-live` position |

> Note: touch-swipe was listed as an example ("e.g.") in the criteria; button + dot + keyboard navigation is implemented. Swipe can be a follow-up if desired.
