### PR TITLE
improvement(screens): enlarge phone mockup for readable screenshots (#7)

### DIFF
--- a/src/components/ScreenshotsSection.jsx
+++ b/src/components/ScreenshotsSection.jsx
@@ -19,12 +19,16 @@ function buildSlides(groups) {
 
 function PhoneShot({ shot }) {
   return (
-    <div className="w-56">
-      {/* iPhone frame — same mockup as the hero, fixed width so every shot matches */}
-      <div className="w-full rounded-[2.25rem] bg-slate-900 p-[6px] shadow-2xl ring-1 ring-white/10">
-        <div className="relative overflow-hidden rounded-[1.9rem] bg-black">
-          {/* Dynamic Island */}
-          <div className="absolute left-1/2 top-2.5 z-20 h-[22px] w-[72px] -translate-x-1/2 rounded-full bg-black" />
+    // Scale the mockup up with the viewport so the in-app content stays legible.
+    // This is the reading-focused carousel, so it runs a touch larger than the
+    // hero mockup (w-64 sm:w-72). The 9:19.5 ratio is very tall, so we cap the
+    // growth at lg to avoid the phone dominating the card vertically.
+    <div className="w-64 sm:w-72 lg:w-80">
+      {/* iPhone frame — same mockup as the hero, scales so every shot matches */}
+      <div className="w-full rounded-[2.5rem] bg-slate-900 p-[6px] shadow-2xl ring-1 ring-white/10">
+        <div className="relative overflow-hidden rounded-[2.2rem] bg-black">
+          {/* Dynamic Island — sized to match the hero mockup at this width */}
+          <div className="absolute left-1/2 top-3 z-20 h-[28px] w-[90px] -translate-x-1/2 rounded-full bg-black" />
           <div className="relative aspect-[9/19.5]">
             <img
               src={`${import.meta.env.BASE_URL}${shot.src}`}


### PR DESCRIPTION
## Summary

The screens slideshow rendered each app screenshot inside a fixed `w-56` (224px) phone mockup. The source screenshots are 1170×2532, so they were downscaled ~5× and the in-app text became unreadable — the exact complaint in #7. This scales the mockup responsively so the in-app content is legible.

## Approach

Single-file change to `PhoneShot` in `ScreenshotsSection.jsx`:
- Width `w-56` → `w-64 sm:w-72 lg:w-80` (scales the rendered screenshot up with the viewport).
- Bumped the frame corner radii (`rounded-[2.25rem]`/`[1.9rem]` → `rounded-[2.5rem]`/`[2.2rem]`) and the Dynamic Island (`h-[22px] w-[72px]` → `h-[28px] w-[90px]`) to match the hero mockup at the larger width.
- **`object-fit` left unchanged.** The image ratio (1170/2532 = 0.4620) is effectively identical to the container's `aspect-[9/19.5]` (0.4615), so `object-cover` crops nothing — size was the only lever that mattered.
- Scoped deliberately: the hero has its own inline mockup, so nothing shared was refactored and the hero cannot regress.

## Decision Record

- **Root cause:** fixed `w-56` thumbnail shrinks 1170px-wide screenshots ~5×.
- **Options considered:**
  - *Minimal* — single larger fixed width. Rejected: no responsive behavior, mobile-overflow risk.
  - *Balanced (selected)* — responsive width bump, island/radii matched to hero. Lowest risk, matches the reporter's literal ask, keeps the carousel's a11y intact.
  - *Comprehensive* — click-to-zoom lightbox for full-res reading. Deferred: new modal/focus-trap surface would risk regressing the carousel's clean a11y; only warranted if size alone proved insufficient (it didn't).
- **Constraint:** the 9:19.5 ratio is very tall, so growth is capped at `lg` (`w-80` ≈ 690px tall) to avoid the phone dominating the card vertically.

## Changes

| File | Change |
|------|--------|
| `src/components/ScreenshotsSection.jsx` | `PhoneShot` mockup width made responsive (`w-64 sm:w-72 lg:w-80`); frame radii + Dynamic Island matched to the hero mockup |

## Test Results

- `npm run build` (vite build) — ✓ passes.
- Visual verification via headless Chromium (the real acceptance test — a build only proves compilation, not legibility):
  - **Desktop (1280px):** phone renders at `w-80` (320px); chat bubbles, the model breakdown bullets, `gemini-3.5-flash`, and the `Ask Anything` field are all clearly readable. No overflow.
  - **Mobile (390px):** no horizontal overflow (`document.scrollWidth == window.innerWidth`, `bodyOverflowX: false`); in-app text legible.
  - **Carousel exercised:** clicked Next to slide 7 (`api-keys-management`, one of the densest screens) — counter advanced to `7 / 9`, caption + image updated, active dot moved. Provider names, status labels, and Edit Key/Test buttons are readable at the new size.

## Acceptance Criteria Verification

| Criterion | Status | Notes |
|-----------|--------|-------|
| In-app content legible on desktop | ✓ met | Verified at 1280px on both the CarPlay slide and the dense api-keys slide |
| Screenshots readable & well-laid-out on mobile | ⚠ met with caveat | Phone scales cleanly at 390px with **no overflow** and legible text. **Caveat:** the pre-existing `FloatingCTA` ("Join the TestFlight beta", `position: fixed bottom-6 left-1/2`) floats over the bottom-center of the centered phone on mobile, partially occluding the screenshot. This is a separate, pre-existing component not introduced or modified here — see follow-up note below |
| Slideshow still functions (navigation) | ✓ met | Empirically confirmed: Next/dots advance the active slide, caption, image, and live counter |
| No layout regressions / overflow on the landing page | ✓ met | No horizontal overflow at mobile width; diff is scoped to `PhoneShot` and the hero mockup is independent |

### Follow-up (not in scope for #7)
On mobile, the global `FloatingCTA` overlaps the screens mockup's bottom-center. It predates this change (and overlapped the smaller mockup too), but the taller mockup makes it more noticeable. Recommend a separate issue to hide/reposition the floating CTA over the `#screens` section on small viewports.

Closes #7