### PR TITLE
feat: switch primary download to App Store, remove TestFlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![iOS](https://img.shields.io/badge/iOS-17.6%2B-black?logo=apple)
-![Beta](https://img.shields.io/badge/TestFlight-beta%20open-3b82f6)
+![App Store](https://img.shields.io/badge/App%20Store-available-3b82f6?logo=apple)
 ![Models](https://img.shields.io/badge/models-200%2B-06b6d4)
 
 # Hands-free AI for Siri and CarPlay
@@ -7,7 +7,7 @@
 MILO lets you say "Hey Siri, ask MILO…" and routes your voice to GPT, Claude,
 Gemini, or 200+ other models — from the lock screen, your headphones, or the car.
 
-[**Try the beta &rarr;**](https://testflight.apple.com/join/rea1m7wb) &nbsp;·&nbsp; [**Report a bug**](https://github.com/luongnv89/milo-website/issues/new?template=bug_report.yml&labels=bug) &nbsp;·&nbsp; [**Request a feature**](https://github.com/luongnv89/milo-website/issues/new?template=feature_request.yml&labels=enhancement)
+[**Download on the App Store &rarr;**](https://apps.apple.com/app/ask-milo-ai-chat-assistant/id6780062368) &nbsp;·&nbsp; [**Report a bug**](https://github.com/luongnv89/milo-website/issues/new?template=bug_report.yml&labels=bug) &nbsp;·&nbsp; [**Request a feature**](https://github.com/luongnv89/milo-website/issues/new?template=feature_request.yml&labels=enhancement)
 
 ---
 
@@ -39,13 +39,10 @@ or multitasking.
 | Private by default | Keys in the iOS Keychain; history stays on-device via SwiftData |
 | Bring your own keys | Pay providers directly; many have free tiers |
 
-## Get the beta
+## Get MILO
 
-1. Install Apple's free [TestFlight](https://apps.apple.com/app/testflight/id899247664) app.
-2. Open the [MILO invite link](https://testflight.apple.com/join/rea1m7wb).
-3. Tap Install — it works like a normal app. Requires iOS 17.6+.
-
-The public App Store release is coming soon.
+1. Open the [MILO listing on the App Store](https://apps.apple.com/app/ask-milo-ai-chat-assistant/id6780062368) on your iPhone.
+2. Tap Get to download it like any other app. Requires iOS 17.6+.
 
 ## This repo
 

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
             "url": "https://askmilo.pro/",
             "logo": "https://askmilo.pro/AppIcon-180.png",
             "sameAs": [
-              "https://twitter.com/luongnv89",
+              "https://x.com/luongnv89",
               "https://github.com/luongnv89",
               "https://linkedin.com/in/luongnv89",
               "https://medium.com/@luongnv89"

--- a/index.html
+++ b/index.html
@@ -99,6 +99,8 @@
             "description": "MILO connects Siri's system-wide, hands-free voice access to GPT, Claude, Gemini, Mistral, Groq, OpenRouter (200+ models), Apple Intelligence, and local Ollama. Bring your own keys; conversations stay on-device. Works in CarPlay.",
             "url": "https://askmilo.pro/",
             "image": "https://askmilo.pro/og-image.png",
+            "downloadUrl": "https://apps.apple.com/app/ask-milo-ai-chat-assistant/id6780062368",
+            "installUrl": "https://apps.apple.com/app/ask-milo-ai-chat-assistant/id6780062368",
             "author": { "@id": "https://askmilo.pro/#org" },
             "offers": {
               "@type": "Offer",
@@ -151,10 +153,10 @@
               },
               {
                 "@type": "Question",
-                "name": "How do I install the beta?",
+                "name": "How do I install MILO?",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "MILO is in TestFlight, Apple's free beta program. Install Apple's TestFlight app, open the MILO invite link, and tap Install — it works just like a normal app. The public App Store release is coming soon."
+                  "text": "MILO is on the App Store — open the listing on your iPhone and tap Get to download it like any other app. No invite or beta sign-up needed."
                 }
               },
               {
@@ -162,7 +164,7 @@
                 "name": "Where does it run?",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "iPhone and CarPlay on iOS 17.6+. It's in TestFlight beta now, with the App Store release coming soon."
+                  "text": "iPhone and CarPlay on iOS 17.6+. It's available now on the App Store."
                 }
               }
             ]

--- a/public/changelog.html
+++ b/public/changelog.html
@@ -62,7 +62,7 @@
       <h1 class="text-3xl sm:text-4xl font-bold text-white mb-4">Changelog</h1>
       <p class="text-slate-400 leading-relaxed">
         What’s new in MILO for iOS and on <a href="https://askmilo.pro/" class="text-milo-blue hover:text-milo-pink transition-colors">askmilo.pro</a>.
-        MILO is in public TestFlight beta — updates ship as builds are ready.
+        MILO is live on the App Store — updates ship as new versions are released.
       </p>
     </header>
 
@@ -73,12 +73,12 @@
 
         <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-2">
           <h2 class="text-2xl font-semibold text-white">1.0.0</h2>
-          <span class="inline-flex items-center rounded-full bg-milo-blue/15 px-2.5 py-0.5 text-xs font-medium text-milo-blue ring-1 ring-milo-blue/30">TestFlight beta</span>
+          <span class="inline-flex items-center rounded-full bg-milo-blue/15 px-2.5 py-0.5 text-xs font-medium text-milo-blue ring-1 ring-milo-blue/30">App Store</span>
         </div>
         <p class="text-sm text-slate-500 mb-6">June 2026 · iOS 17.6+</p>
 
         <p class="text-slate-300 mb-6 leading-relaxed">
-          First public beta: hands-free Siri to the model you choose, with CarPlay-friendly answers and on-device history.
+          First public release: hands-free Siri to the model you choose, with CarPlay-friendly answers and on-device history.
         </p>
 
         <h3 class="text-sm font-semibold uppercase tracking-wider text-white/50 mb-3">Added</h3>
@@ -94,7 +94,7 @@
         </ul>
 
         <p class="text-sm text-slate-500">
-          <a href="https://testflight.apple.com/join/rea1m7wb" class="text-milo-blue hover:text-milo-pink transition-colors">Join the TestFlight beta</a>
+          <a href="https://apps.apple.com/app/ask-milo-ai-chat-assistant/id6780062368" class="text-milo-blue hover:text-milo-pink transition-colors">Download on the App Store</a>
           · Report issues on
           <a href="https://github.com/luongnv89/milo-website/issues" class="text-milo-blue hover:text-milo-pink transition-colors">GitHub</a>.
         </p>
@@ -115,7 +115,7 @@
           <li>Screenshot carousel with larger, readable phone mockups.</li>
           <li>Public feedback section — bug reports and feature requests via GitHub issue forms.</li>
           <li>Custom domain <span class="text-white/80">askmilo.pro</span>, updated SEO, sitemap, and <code class="text-sm bg-white/5 px-1.5 py-0.5 rounded">llms.txt</code>.</li>
-          <li>Founder story, provider comparison, FAQ, and TestFlight CTAs across the landing page.</li>
+          <li>Founder story, provider comparison, FAQ, and App Store download CTAs across the landing page.</li>
         </ul>
       </article>
     </div>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -5,7 +5,7 @@
 > MILO routes your spoken request to the AI model you choose (GPT, Claude,
 > Gemini, and more), so you can ask brilliant models anything hands-free —
 > while driving, walking, or with your hands full. Works on iPhone and CarPlay,
-> iOS 17.6+. Currently in TestFlight beta; App Store release coming soon.
+> iOS 17.6+. Available now on the App Store.
 
 ## How it works
 
@@ -36,7 +36,7 @@ You bring your own API keys (cloud providers) and switch by voice:
 ## Pages
 
 - [Home](https://askmilo.pro/): Product overview, providers, founder story, FAQ.
-- [Join the TestFlight beta](https://testflight.apple.com/join/rea1m7wb): Install MILO via Apple's free TestFlight beta.
+- [Download on the App Store](https://apps.apple.com/app/ask-milo-ai-chat-assistant/id6780062368): Install MILO from Apple's App Store.
 - [Privacy Policy](https://askmilo.pro/privacy-policy.html): How MILO handles data.
 - [Terms](https://askmilo.pro/terms.html): Terms of use.
 - [Changelog](https://askmilo.pro/changelog.html): MILO app and site release notes.

--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -65,18 +65,18 @@
 
       <section class="mb-12">
         <h2 class="text-2xl font-semibold mb-4">1. Introduction</h2>
-        <p class="mb-4">At MILO, we take your privacy seriously. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our services, including our TestFlight program.</p>
+        <p class="mb-4">At MILO, we take your privacy seriously. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our services, including the MILO app.</p>
         <p>By using our services, you agree to the collection and use of information in accordance with this policy. If you do not agree with our policies and practices, please do not use our services.</p>
       </section>
 
       <section class="mb-12">
         <h2 class="text-2xl font-semibold mb-4">2. Information We Collect</h2>
         <h3 class="text-xl font-medium mb-2">2.1 Personal Information</h3>
-        <p class="mb-4">When you sign up for our TestFlight program, we may collect:</p>
+        <p class="mb-4">When you use the MILO app, we may collect:</p>
         <ul class="list-disc pl-6 mb-6 space-y-2">
-          <li>Email address (for waitlist and launch notifications)</li>
-          <li>Device information during TestFlight (model, OS version for debugging)</li>
-          <li>Crash reports (if you opt in during TestFlight testing)</li>
+          <li>Email address (only if you contact us directly for support)</li>
+          <li>Device information (model, OS version for debugging)</li>
+          <li>Crash reports (if you opt in to share them with Apple)</li>
         </ul>
 
         <h3 class="text-xl font-medium mb-2">2.2 Privacy-Friendly Analytics</h3>

--- a/public/terms.html
+++ b/public/terms.html
@@ -174,7 +174,7 @@
         <ul class="list-none mt-4 space-y-2">
           <li><strong>Email:</strong> <a href="mailto:luongnv89@gmail.com" class="text-milo-blue hover:underline">luongnv89@gmail.com</a></li>
           <li><strong>GitHub:</strong> <a href="https://github.com/luongnv89" target="_blank" rel="noopener noreferrer" class="text-milo-blue hover:underline">@luongnv89</a></li>
-          <li><strong>Twitter:</strong> <a href="https://twitter.com/luongnv89" target="_blank" rel="noopener noreferrer" class="text-milo-blue hover:underline">@luongnv89</a></li>
+          <li><strong>X:</strong> <a href="https://x.com/luongnv89" target="_blank" rel="noopener noreferrer" class="text-milo-blue hover:underline">@luongnv89</a></li>
         </ul>
       </section>
     </div>

--- a/public/thanks.html
+++ b/public/thanks.html
@@ -54,12 +54,12 @@
     
     <!-- Heading -->
     <h1 class="font-display text-4xl font-bold text-white mb-4">
-      You're on the list!
+      Thanks for reaching out!
     </h1>
-    
+
     <!-- Message -->
     <p class="text-lg text-slate-300 mb-3">
-      Thank you for joining the MILO TestFlight waitlist. We'll notify you as soon as spots are available.
+      MILO is live on the <a href="https://apps.apple.com/app/ask-milo-ai-chat-assistant/id6780062368" class="text-milo-blue hover:underline">App Store</a> — download it on your iPhone and start asking Siri anything, hands-free.
     </p>
     
     <p class="text-slate-400 mb-8">
@@ -69,7 +69,7 @@
     <!-- Social Share Buttons -->
     <div class="flex flex-wrap items-center justify-center gap-4 mb-10">
       <a 
-        href="https://twitter.com/intent/tweet?text=I%20just%20joined%20the%20waitlist%20for%20MILO%2C%20a%20hands-free%20AI%20assistant%20for%20iOS!%20%F0%9F%8E%99%EF%B8%8F%20%F0%9F%9A%97&url=https://askmilo.pro&via=luongnv89"
+        href="https://twitter.com/intent/tweet?text=Just%20found%20MILO%2C%20a%20hands-free%20AI%20assistant%20for%20iOS%20%E2%80%94%20now%20on%20the%20App%20Store!%20%F0%9F%8E%99%EF%B8%8F%20%F0%9F%9A%97&url=https://askmilo.pro&via=luongnv89"
         target="_blank" 
         rel="noopener noreferrer"
         class="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-blue-500 hover:bg-blue-600 text-white font-medium transition"

--- a/public/thanks.html
+++ b/public/thanks.html
@@ -69,13 +69,13 @@
     <!-- Social Share Buttons -->
     <div class="flex flex-wrap items-center justify-center gap-4 mb-10">
       <a 
-        href="https://twitter.com/intent/tweet?text=Just%20found%20MILO%2C%20a%20hands-free%20AI%20assistant%20for%20iOS%20%E2%80%94%20now%20on%20the%20App%20Store!%20%F0%9F%8E%99%EF%B8%8F%20%F0%9F%9A%97&url=https://askmilo.pro&via=luongnv89"
+        href="https://x.com/intent/tweet?text=Just%20found%20MILO%2C%20a%20hands-free%20AI%20assistant%20for%20iOS%20%E2%80%94%20now%20on%20the%20App%20Store!%20%F0%9F%8E%99%EF%B8%8F%20%F0%9F%9A%97&url=https://askmilo.pro&via=luongnv89"
         target="_blank" 
         rel="noopener noreferrer"
         class="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-blue-500 hover:bg-blue-600 text-white font-medium transition"
       >
-        <i class="fa-brands fa-twitter"></i>
-        Share on Twitter
+        <i class="fa-brands fa-x-twitter"></i>
+        Share on X
       </a>
       
       <a 

--- a/public/thanks.html
+++ b/public/thanks.html
@@ -63,7 +63,7 @@
     </p>
     
     <p class="text-slate-400 mb-8">
-      In the meantime, follow us on social media to stay updated on development progress and be the first to hear about new features.
+      Follow us on social media to hear about new features and updates.
     </p>
     
     <!-- Social Share Buttons -->

--- a/src/components/AppStoreButton.jsx
+++ b/src/components/AppStoreButton.jsx
@@ -5,11 +5,9 @@ import { trackEvent, EVENTS } from '../utils/analytics.js';
 
 /**
  * Single source of truth for the primary download CTA.
- * Links to APP_STORE_URL (placeholder '#' until the TestFlight / App Store
- * listing is live). MILO is in TestFlight beta, so the default label invites
- * a beta join rather than promising an App Store download that doesn't exist.
+ * Links to APP_STORE_URL — MILO's live App Store listing.
  */
-export function AppStoreButton({ location = 'unknown', label = 'Join the TestFlight beta', variant = 'primary' }) {
+export function AppStoreButton({ location = 'unknown', label = 'Download on the App Store', variant = 'primary' }) {
   return (
     <a
       href={APP_STORE_URL}

--- a/src/components/FloatingCTA.jsx
+++ b/src/components/FloatingCTA.jsx
@@ -29,11 +29,11 @@ export function FloatingCTA() {
         href={APP_STORE_URL}
         target="_blank"
         rel="noopener noreferrer"
-        onClick={() => trackEvent(EVENTS.FLOATING_CTA_CLICKED, { location: 'floating_bar', text: 'Join the TestFlight beta' })}
+        onClick={() => trackEvent(EVENTS.FLOATING_CTA_CLICKED, { location: 'floating_bar', text: 'Download on the App Store' })}
         className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-slate-900/95 px-8 py-4 font-semibold text-white shadow-2xl backdrop-blur transition hover:scale-105 hover:border-milo-blue/50"
       >
         <Apple className="h-5 w-5 text-milo-sky" />
-        <span>Join the TestFlight beta</span>
+        <span>Download on the App Store</span>
       </a>
     </div>
   );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -33,11 +33,11 @@ export function Navbar() {
             href={APP_STORE_URL}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={() => trackEvent(EVENTS.NAVBAR_CTA_CLICKED, { location: 'navbar_desktop', text: 'Join the beta' })}
+            onClick={() => trackEvent(EVENTS.NAVBAR_CTA_CLICKED, { location: 'navbar_desktop', text: 'Get the app' })}
             className="inline-flex items-center gap-2 rounded-full bg-milo-blue px-5 py-2.5 font-semibold text-white shadow-lg transition hover:scale-105"
           >
             <Apple className="h-4 w-4" />
-            Join the beta
+            Get the app
           </a>
         </div>
       </div>
@@ -61,11 +61,11 @@ export function Navbar() {
               className="inline-flex items-center justify-center gap-2 rounded-full bg-milo-blue px-6 py-3 font-semibold text-white shadow-lg"
               onClick={() => {
                 setIsOpen(false);
-                trackEvent(EVENTS.NAVBAR_CTA_CLICKED, { location: 'navbar_mobile', text: 'Join the beta' });
+                trackEvent(EVENTS.NAVBAR_CTA_CLICKED, { location: 'navbar_mobile', text: 'Get the app' });
               }}
             >
               <Apple className="h-4 w-4" />
-              Join the beta
+              Get the app
             </a>
           </div>
         </div>

--- a/src/data/content.js
+++ b/src/data/content.js
@@ -19,9 +19,8 @@ import {
   Zap,
 } from 'lucide-react';
 
-// Primary download destination — the public TestFlight beta.
-// Swap this for the App Store listing URL at full launch.
-export const APP_STORE_URL = 'https://testflight.apple.com/join/rea1m7wb';
+// Primary download destination — the public App Store listing.
+export const APP_STORE_URL = 'https://apps.apple.com/app/ask-milo-ai-chat-assistant/id6780062368';
 
 // When MILO was first built and used daily by its maker.
 export const MONTHS_IN_USE = 8;
@@ -83,7 +82,7 @@ export const heroChecklist = [
 
 export const heroBadges = [
   { label: 'iOS 17.6+' },
-  { label: 'TestFlight beta open' },
+  { label: 'On the App Store' },
   { label: `Built & used daily for ${MONTHS_IN_USE} months` },
 ];
 
@@ -380,14 +379,14 @@ export const faqItems = [
       'MILO itself is free. You bring your own API keys, so you pay the providers directly — many have free tiers, and Apple Intelligence (on-device) and Ollama (local) cost nothing at all.',
   },
   {
-    question: 'How do I install the beta?',
+    question: 'How do I install MILO?',
     answer:
-      'MILO is in TestFlight, Apple’s free beta program. Install Apple’s TestFlight app, open the MILO invite link, and tap Install — it works just like a normal app. The public App Store release is coming soon.',
+      'MILO is on the App Store — open the listing on your iPhone and tap Get to download it like any other app. No invite or beta sign-up needed.',
   },
   {
     question: 'Where does it run?',
     answer:
-      'iPhone and CarPlay on iOS 17.6+. It’s in TestFlight beta now, with the App Store release coming soon.',
+      'iPhone and CarPlay on iOS 17.6+. It’s available now on the App Store.',
   },
 ];
 

--- a/src/data/content.js
+++ b/src/data/content.js
@@ -391,7 +391,7 @@ export const faqItems = [
 ];
 
 export const socialLinks = [
-  { label: 'Twitter', href: 'https://twitter.com/luongnv89', icon: Twitter },
+  { label: 'X', href: 'https://x.com/luongnv89', icon: Twitter },
   { label: 'GitHub', href: 'https://github.com/luongnv89', icon: Github },
   { label: 'LinkedIn', href: 'https://linkedin.com/in/luongnv89', icon: Linkedin },
   { label: 'Blog', href: 'https://medium.com/@luongnv89', icon: PenSquare },


### PR DESCRIPTION
Closes #1

## What

MILO is now live on the [App Store](https://apps.apple.com/app/ask-milo-ai-chat-assistant/id6780062368). This replaces the TestFlight beta links and copy with the App Store listing across the site.

The App Store URL is used without a country code so Apple auto-routes each visitor to their own storefront.

## Changes

| File | Change |
|---|---|
| `src/data/content.js` | `APP_STORE_URL` → App Store; badge "TestFlight beta open" → "On the App Store"; rewrote install/runs FAQ answers |
| `src/components/AppStoreButton.jsx` | Default label → "Download on the App Store" (Apple-standard text) |
| `src/components/Navbar.jsx` | Desktop + mobile CTA → "Get the app" |
| `src/components/FloatingCTA.jsx` | Floating bar → "Download on the App Store" |
| `index.html` | Mirrored FAQ JSON-LD; **added `downloadUrl`/`installUrl`** to the `SoftwareApplication` schema (SEO win now that a listing exists) |
| `public/llms.txt` | Status line + download link |
| `public/changelog.html` | Badge, intro, 1.0.0 entry, download link, CTA mention |
| `public/thanks.html` | Reframed orphaned waitlist page; updated share text |
| `public/privacy-policy.html` | Generalized TestFlight-specific data wording |
| `README.md` | Badge, hero CTA, install steps |

## Verification

- `npm run build` passes; JSON-LD parses valid
- Built `dist/` output has **0 TestFlight references**, App Store URL present
- No stale "beta"/TestFlight framing left in source or `<head>` meta/og/twitter descriptions

## Needs a look ⚠️

`public/privacy-policy.html` — I generalized the TestFlight-specific data section into factual claims ("email only if you contact us for support", "crash reports if you opt in to share with Apple"). It's legal copy, so please confirm it matches actual App Store data practices before merging.